### PR TITLE
Update to make /etc/hosts change optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ the hostname and the domain, eg:
     hostname::hostname: host1
     hostname::domain: example.com
 
+Also, the module can update /etc/hosts if so desired, eg:
+
+    hostname::updatehosts: true
 
 Include the module in the usual fashion, ideally somewhere like your SOE module
 so your hostname is set before the installation of most services.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,7 @@ class hostname (
   $domain             = $hostname::params::domain,
   $ip                 = $hostname::params::ip,
   $reloads            = $hostname::params::reloads,
+  $edit_hosts            = $hostname::params::edit_hosts,
   ) inherits hostname::params {
 
   # Generate hostname
@@ -34,26 +35,28 @@ class hostname (
   }
 
   # Make sure the hosts file has an entry
-  host { 'default hostname v4':
-    ensure        => present,
-    name          => $set_fqdn,
-    host_aliases  => $hostname,
-    ip            => $ip,
-    comment       => 'Hostname and FQDN',
-  }
+  if ($edit_hosts) {
+    host { 'default hostname v4':
+      ensure        => present,
+      name          => $set_fqdn,
+      host_aliases  => $hostname,
+      ip            => $ip,
+      comment       => 'Hostname and FQDN',
+    }
 
   # If using FQDN, make sure the old hostname hostname entry has been removed
   # otherwise the FQDN will not work. This should be fixed by use of comment
   # parameter above from 2017-01-18 onwards so at some stage this block could
   # be removed.
-  if ($domain) {
-    host { 'hostname without fqdn':
-      ensure        => absent,
-      name          => $hostname,
-      host_aliases  => $hostname,
-      ip            => $ip,
+    if ($domain) {
+      host { 'hostname without fqdn':
+        ensure        => absent,
+        name          => $hostname,
+        host_aliases  => $hostname,
+        ip            => $ip,
+      }
     }
-  }
+  }  
 
 # TODO: This won't work yet thanks to an ancient puppet bug:
 # https://projects.puppetlabs.com/issues/8940

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,7 +4,7 @@ class hostname (
   $domain             = $hostname::params::domain,
   $ip                 = $hostname::params::ip,
   $reloads            = $hostname::params::reloads,
-  $edit_hosts            = $hostname::params::edit_hosts,
+  $updatehosts            = $hostname::params::updatehosts,
   ) inherits hostname::params {
 
   # Generate hostname
@@ -35,7 +35,7 @@ class hostname (
   }
 
   # Make sure the hosts file has an entry
-  if ($edit_hosts) {
+  if ($updatehosts) {
     host { 'default hostname v4':
       ensure        => present,
       name          => $set_fqdn,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,9 @@ class hostname::params () {
   # Define the IP
   $ip = '127.0.0.1'
 
+ # Added switch to bypass /etc/hosts edits
+  $edit_hosts = false
+
   # Array of Puppet service names to be reloaded after hostname change.
   # Generally you will need to at least restart syslog (or variant).
   $reloads = []

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class hostname::params () {
   $ip = '127.0.0.1'
 
  # Added switch to bypass /etc/hosts edits
-  $edit_hosts = false
+  $updatehosts = false
 
   # Array of Puppet service names to be reloaded after hostname change.
   # Generally you will need to at least restart syslog (or variant).


### PR DESCRIPTION
Hey @jethrocarr-

  An issue in our environment led to this change, just a simple option to disable the /etc/hosts entry. It caused some loopback issues in an application that is not designed to listen on the loopback IP (127.0.0.1). 

Thanks-
P